### PR TITLE
[cpp][17_skiplist] impl of an STL-like skiplist container.

### DIFF
--- a/c-cpp/17_skiplist/skiplist_tr.hpp
+++ b/c-cpp/17_skiplist/skiplist_tr.hpp
@@ -1,0 +1,17 @@
+/**
+ * Created by Liam Huang (Liam0205) on 2018/10/30.
+ */
+
+#ifndef SKIPLIST_SKIPLIST_TR_HPP_
+#define SKIPLIST_SKIPLIST_TR_HPP_
+
+#include <functional>
+
+template <typename Value,
+          typename Compare = std::less<Value>>
+class skiplist {
+
+};
+
+#endif  // SKIPLIST_SKIPLIST_TR_HPP_
+

--- a/c-cpp/17_skiplist/skiplist_tr.hpp
+++ b/c-cpp/17_skiplist/skiplist_tr.hpp
@@ -5,12 +5,37 @@
 #ifndef SKIPLIST_SKIPLIST_TR_HPP_
 #define SKIPLIST_SKIPLIST_TR_HPP_
 
+#include <set>
+#include <vector>
+#include <list>
 #include <functional>
+#include <type_traits>
+
+namespace skiplist_detail {
+template <typename Key, typename Value>
+struct InternalNode {
+    const Key                                               key;
+    std::multiset<Value>                                    values;
+    using iterator = typename std::list<InternalNode>::iterator;
+    std::vector<iterator> forwards;
+};
+}  // namespace skiplist_detail
 
 template <typename Value,
-          typename Compare = std::less<Value>>
+          typename Compare = std::less<Value>,
+          typename Hash = std::hash<Value>>
 class skiplist {
-
+  public:
+    using value_type = Value;
+    using compare    = Compare;
+    using size_type  = size_t;
+    using hasher     = Hash;
+    using hash_type  = typename Hash::result_type;
+    using node_type  = skiplist_detail::InternalNode<hash_type, value_type>;
+    using container  = std::list<node_type>;
+    using iterator   = typename container::iterator;
+    static_assert(std::is_same<iterator, typename node_type::iterator>::value,
+            "STATIC ASSERT FAILED! iterator type differs.");
 };
 
 #endif  // SKIPLIST_SKIPLIST_TR_HPP_

--- a/c-cpp/17_skiplist/skiplist_tr.hpp
+++ b/c-cpp/17_skiplist/skiplist_tr.hpp
@@ -5,12 +5,21 @@
 #ifndef SKIPLIST_SKIPLIST_TR_HPP_
 #define SKIPLIST_SKIPLIST_TR_HPP_
 
+#ifdef LIAM_UT_DEBUG_
+#include <assert.h>
+#include <iostream>
+#endif
+
 #include <set>
 #include <vector>
 #include <list>
 #include <functional>
 #include <type_traits>
 #include <random>
+#include <limits>
+#include <algorithm>
+#include <initializer_list>
+#include <iterator>
 
 namespace skiplist_detail {
 template <typename Key, typename Value>
@@ -19,6 +28,9 @@ struct InternalNode {
     const Key             key;
     std::multiset<Value>  values;
     std::vector<iterator> forwards;
+
+    InternalNode() = delete;
+    explicit InternalNode(const Key& k) : key(k) {}
 };
 
 template <typename IntType>
@@ -51,12 +63,73 @@ class skiplist {
             "STATIC ASSERT FAILED! iterator type differs.");
 
   private:
-    size_type                       max_lv_ = 16;
-    double                          prob_   = 0.5;
-    mutable random_level<size_type> rl_;
+    size_type                                        max_lv_ = 16;
+    double                                           prob_   = 0.5;
+    mutable skiplist_detail::random_level<size_type> rl_;
+    container                                        cont_;
 
   public:
-    skiplist() : rl_(max_lv_, prob_) {}
+    skiplist() : rl_(max_lv_, prob_) {
+        init_internally();
+    }
+    explicit skiplist(const size_type max_lv, const double prob = 0.5)
+        : max_lv_(max_lv), prob_(prob), rl_(max_lv_, prob_) {
+        init_internally();
+    }
+    skiplist(skiplist&& other) = default;
+    skiplist& operator=(skiplist&& other) = default;
+    ~skiplist() = default;
+    template <typename InputIt>
+    skiplist(InputIt first, InputIt last) : skiplist() {
+        using value_type_in_iter = typename std::iterator_traits<InputIt>::value_type;
+        static_assert(std::is_same<value_type, value_type_in_iter>::value,
+                "STATIC ASSERT FAILED! Value in InputIt should be the same to value_type.");
+        for (InputIt i = first; i != last; ++i) {
+            insert(*i);
+        }
+    }
+    skiplist(std::initializer_list<value_type> init) : skiplist(init.begin(), init.end()) {}
+
+  private:  // noncopyable
+    skiplist(const skiplist&) = delete;
+    skiplist& operator=(const skiplist&) = delete;
+
+  private:
+    void init_internally() {
+        const hash_type tail_key = std::numeric_limits<hash_type>::max();
+        node_type tail(tail_key);
+        tail.forwards.resize(max_lv_);
+        std::fill(tail.forwards.begin(), tail.forwards.end(), cont_.end());
+        cont_.insert(cont_.begin(), std::move(tail));
+
+        const hash_type head_key = std::numeric_limits<hash_type>::min();
+        node_type head(head_key);
+        head.forwards.resize(max_lv_);
+        cont_.insert(cont_.begin(), std::move(head));
+        std::fill(cont_.begin()->forwards.begin(), cont_.begin()->forwards.end(),
+                std::next(cont_.begin()));
+
+#ifdef LIAM_UT_DEBUG_
+        assert(cont_.begin()->key == head_key);
+        for (auto it : cont_.begin()->forwards) {
+            assert(it->key == tail_key);
+        }
+        for (auto it : std::next(cont_.begin())->forwards) {
+            assert(it == cont_.end());
+        }
+        std::cerr << "all assert in init() success!\n";
+#endif
+
+        return;
+    }
+
+  public:
+    size_type size() const {
+        return cont_.size() - 2;
+    }
+    bool empty() const {
+        return size() == 0;
+    }
 };
 
 #endif  // SKIPLIST_SKIPLIST_TR_HPP_

--- a/c-cpp/17_skiplist/skiplist_tr_test.cc
+++ b/c-cpp/17_skiplist/skiplist_tr_test.cc
@@ -1,6 +1,7 @@
 /**
  * Created by Liam Huang (Liam0205) on 2018/10/30.
  */
+#include <assert.h>
 
 #include <iostream>
 #include <map>
@@ -19,6 +20,9 @@ int main() {
         std::cout << p.first << ' ' << std::string(p.second / 100, '*') << '\n';
     }
 
+    // 2. UT for skiplist(), init(), size(), empty()
+    skiplist<std::string> sl_default;
+    assert(sl_default.empty());
     return 0;
 }
 

--- a/c-cpp/17_skiplist/skiplist_tr_test.cc
+++ b/c-cpp/17_skiplist/skiplist_tr_test.cc
@@ -3,11 +3,22 @@
  */
 
 #include <iostream>
+#include <map>
+#include <string>
 
 #include "skiplist_tr.hpp"
 
 int main() {
-    std::cout << "hello world" << std::endl;
+    // 1. UT for skiplist_detail::random_level
+    skiplist_detail::random_level<size_t> rl(5, 0.5);
+    std::map<size_t, size_t>    hist;
+    for (size_t i = 0; i != 10000; ++i) {
+        ++hist[rl()];
+    }
+    for (auto p : hist) {
+        std::cout << p.first << ' ' << std::string(p.second / 100, '*') << '\n';
+    }
+
     return 0;
 }
 

--- a/c-cpp/17_skiplist/skiplist_tr_test.cc
+++ b/c-cpp/17_skiplist/skiplist_tr_test.cc
@@ -1,0 +1,13 @@
+/**
+ * Created by Liam Huang (Liam0205) on 2018/10/30.
+ */
+
+#include <iostream>
+
+#include "skiplist_tr.hpp"
+
+int main() {
+    std::cout << "hello world" << std::endl;
+    return 0;
+}
+

--- a/c-cpp/17_skiplist/skiplist_tr_test.cc
+++ b/c-cpp/17_skiplist/skiplist_tr_test.cc
@@ -23,6 +23,12 @@ int main() {
     // 2. UT for skiplist(), init_internally(), size(), empty()
     skiplist<std::string> sl_default;
     assert(sl_default.empty());
+    // 2.1. UT for grow with abandon
+    sl_default.grow(1);
+    assert(sl_default.capability() == 4);
+    // 2.2. UT for grow
+    sl_default.grow(10);
+    assert(sl_default.capability() == 1024);
 
     // 3. UT for constructor of initializer_list and InputIt, init_internally(), insert(),
     // find_predecessors()
@@ -81,7 +87,7 @@ int main() {
     assert(search != sl.cend());
     assert(search != sl.end());
     assert(search->values.count("world") == 2);
-    // 7.1. same word
+    // 7.1. same word, also UT for grow()
     search = sl.find("hello");
     assert(search == sl.cend());
     assert(search == sl.end());

--- a/c-cpp/17_skiplist/skiplist_tr_test.cc
+++ b/c-cpp/17_skiplist/skiplist_tr_test.cc
@@ -20,14 +20,82 @@ int main() {
         std::cout << p.first << ' ' << std::string(p.second / 100, '*') << '\n';
     }
 
-    // 2. UT for skiplist(), init(), size(), empty()
+    // 2. UT for skiplist(), init_internally(), size(), empty()
     skiplist<std::string> sl_default;
     assert(sl_default.empty());
 
-    // 3. UT for find() [nonexist element]
+    // 3. UT for constructor of initializer_list and InputIt, init_internally(), insert(),
+    // find_predecessors()
+    skiplist<std::string> sl{"hello", "world", "!"};
+    assert(not sl.empty());
+    assert(3 == sl.size());
+
+    // 4. UT for find() find_helper()
     auto search = sl_default.find("nonexist");
     assert(search == sl_default.cend());
     assert(search == sl_default.end());
+    search = sl.find("hello");
+    assert(search != sl.cend());
+    assert(search != sl.end());
+    search = sl.find("nonexist");
+    assert(search == sl.cend());
+    assert(search == sl.end());
+
+    // 5. UT for insert(), find_predecessors()
+    // 5.1. UT for insert a already-exist item
+    sl.insert("hello");
+    search = sl.find("hello");
+    assert(search != sl.cend());
+    assert(search != sl.end());
+    // 5.2. UT for insert a new incoming item
+    search = sl.find("now exist");
+    assert(search == sl.cend());
+    assert(search == sl.end());
+    sl.insert("now exist");
+    search = sl.find("now exist");
+    assert(search != sl.cend());
+    assert(search != sl.end());
+
+    // 6. UT for erase(), find_predecessors()
+    sl.insert("hello");
+    sl.insert("hello");
+    sl.insert("hello");
+    sl.insert("hello");
+    // 6.1. UT for erase single item
+    sl.erase("hello", erase_policy::SINGLE);
+    search = sl.find("hello");
+    assert(search != sl.cend());
+    assert(search != sl.end());
+    // 6.2. UT for erase all items
+    sl.erase("hello", erase_policy::ALL);
+    search = sl.find("hello");
+    assert(search == sl.cend());
+    assert(search == sl.end());
+    // 6.3 UT for erase non-exist item
+    sl.erase("nonexist");
+
+    // 7. UT for insert() behind erase()
+    // 7.1. different word
+    sl.insert("world");
+    search = sl.find("world");
+    assert(search != sl.cend());
+    assert(search != sl.end());
+    assert(search->values.count("world") == 2);
+    // 7.1. same word
+    search = sl.find("hello");
+    assert(search == sl.cend());
+    assert(search == sl.end());
+    sl.insert("hello");
+    sl.insert("hello");
+    sl.insert("hello");
+    sl.insert("hello");
+    sl.insert("hello");
+    search = sl.find("hello");
+    assert(search != sl.cend());
+    assert(search != sl.end());
+    assert(search->values.count("hello") == 5);
+
     return 0;
+    // 8. UT for ~skiplist()
 }
 

--- a/c-cpp/17_skiplist/skiplist_tr_test.cc
+++ b/c-cpp/17_skiplist/skiplist_tr_test.cc
@@ -23,6 +23,11 @@ int main() {
     // 2. UT for skiplist(), init(), size(), empty()
     skiplist<std::string> sl_default;
     assert(sl_default.empty());
+
+    // 3. UT for find() [nonexist element]
+    auto search = sl_default.find("nonexist");
+    assert(search == sl_default.cend());
+    assert(search == sl_default.end());
     return 0;
 }
 


### PR DESCRIPTION
* inner container based on `std::list`
* hash incoming value by `std::hash`
* sort by the result of hash value
* automatically grow when the skiplist is almost full, comparing to its ideal capability (`(factor - 1) / factor * std::pow(factor, max_lv_)`).