### PR TITLE
翻转单链表头结点没有初始化

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,3 @@
 # Java rate limiting library/framework
 # https://github.com/wangzheng0822/ratelimiter4j
 
-# sutaoyu
-

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 
 # Java rate limiting library/framework
 # https://github.com/wangzheng0822/ratelimiter4j
+
+# sutaoyu
+

--- a/c-cpp/06_linkedlist/single_list.c
+++ b/c-cpp/06_linkedlist/single_list.c
@@ -74,7 +74,7 @@ struct single_list** search(struct single_list_head* head, int target)
 
 void reverse(struct single_list_head* head)
 {
-	struct single_list_head tmp;
+	struct single_list_head tmp = {NULL};
 	struct single_list *elem;
 
 	while (!is_empty(head)) {


### PR DESCRIPTION
翻转单链表，头结点没有初始化，会导致后面遍历链表无法进行