### PR TITLE
fixed lru array removeAndCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.tar.gz
 *.rar
 *.DS_Store
+*.exe
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/java/06_linkedlist/LRUBasedArray.java
+++ b/java/06_linkedlist/LRUBasedArray.java
@@ -81,7 +81,8 @@ public class LRUBasedArray<T> {
      * @param object
      */
     public void removeAndCache(T object) {
-        value[--count] = null;
+        T key = value[--count];
+        holder.remove(key);
         cache(object, count);
     }
 


### PR DESCRIPTION
When i use the follow unit test,it is fault:
```
    @Test
    public void specifiedConstructorTest() {
        LRUBaseArray<Integer> lru = new LRUBaseArray<>(4);
        lru.offer(1);
        lru.offer(2);
        lru.offer(3);
        lru.offer(4);
        assertEquals(4, (int)lru.getValueByIndex(0));
        lru.offer(2);
        assertEquals(2, (int)lru.getValueByIndex(0));
        assertEquals(4, (int)lru.getValueByIndex(1));
        assertEquals(3, (int)lru.getValueByIndex(2));
        assertEquals(1, (int)lru.getValueByIndex(3));
        lru.offer(4);
        System.out.println(lru);
        assertEquals(4, (int)lru.getValueByIndex(0));
        assertEquals(2, (int)lru.getValueByIndex(1));
        lru.offer(7);
        assertEquals(7, (int)lru.getValueByIndex(0));
        assertEquals(3, (int)lru.getValueByIndex(3));
        System.out.println(lru);
        lru.offer(1);
        System.out.println(lru);
        assertEquals(1, (int)lru.getValueByIndex(0));
        assertEquals(7, (int)lru.getValueByIndex(1));
    }
```