### PR TITLE
fix bug java.12_sorts.KthSmallest

### DIFF
--- a/java/12_sorts/KthSmallest.java
+++ b/java/12_sorts/KthSmallest.java
@@ -27,8 +27,9 @@ public class KthSmallest {
         int pivot = arr[r];
 
         int i = p;
-        for (int j = p; j <= r - 1; j++) {
-            if (arr[j] < pivot) {
+        for (int j = p; j < r; j++) {
+            // 这里要是 <= ，不然会出现死循环，比如查找数组 [1,1,2] 的第二小的元素
+            if (arr[j] <= pivot) {
                 swap(arr, i, j);
                 i++;
             }


### PR DESCRIPTION
这个地方应该是 `arr[j] <= pivot`，不然会出现死循环，比如查找数组 [1,1,2] 的第二小的元素