### PR TITLE
删除函数delete中的搬移内存操作应该减多一个1

### DIFF
--- a/c-cpp/05_array/array.c
+++ b/c-cpp/05_array/array.c
@@ -47,7 +47,7 @@ int delete(struct array *array, int idx)
 		return -1;
 
 	memmove(&array->arr[idx], &array->arr[idx+1],
-		(array->used - idx) * sizeof(int));
+		(array->used - idx - 1) * sizeof(int));
 	array->used--;
 	return 0;
 }


### PR DESCRIPTION
如果不减多一个1，会将数组内存中未使用的第一个内存地址中的内容也复制到
已经使用的内存地址中。