### PR TITLE
java中public类名必须跟文件名一致，将不一致的StackBasedOnLinkedList修改成一致；在.gitignore中配置…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+
+**/*.idea
+**/*.iml
+**/*out

--- a/java/08_stack/StackBasedOnLinkedList.java
+++ b/java/08_stack/StackBasedOnLinkedList.java
@@ -5,7 +5,7 @@ package stack;
  *
  * Author: Zheng
  */
-public class StackBasedLinkedList {
+public class StackBasedOnLinkedList {
   private Node top = null;
 
   public void push(int value) {


### PR DESCRIPTION
Java 中 public 类名必须跟文件名一致，将不一致的StackBasedOnLinkedList修改成一致；
在 .gitignore 中排除IntelliJ idea 项目配置文件。