### PR TITLE
del函数参数的临界值指针判空

### DIFF
--- a/c-cpp/06_linkedlist/single_list.c
+++ b/c-cpp/06_linkedlist/single_list.c
@@ -47,7 +47,8 @@ struct single_list* del(struct single_list **prev)
 
 	if (!prev)
 		return NULL;
-
+	if (*prev == null)
+		return NULL;
 	tmp = *prev;
 	*prev = (*prev)->next;
 	tmp->next = NULL;


### PR DESCRIPTION
入参若为：&（尾结点.next）
指针有必要判空