### PR TITLE
fix bug in deleting method

### DIFF
--- a/c-cpp/24_tree/binarysearchtree.c
+++ b/c-cpp/24_tree/binarysearchtree.c
@@ -88,7 +88,7 @@ Status Delete(BTreePtr T, ElemType e) {
             minP = minP->lchild;
         }
         p->data = minP->data;
-        minpp->lchild = minpp->rchild;
+        minPP->lchild = minP->rchild;
         free(minP);
 
         return TRUE;

--- a/c-cpp/24_tree/binarysearchtree.c
+++ b/c-cpp/24_tree/binarysearchtree.c
@@ -88,8 +88,8 @@ Status Delete(BTreePtr T, ElemType e) {
             minP = minP->lchild;
         }
         p->data = minP->data;
+        minpp->lchild = minpp->rchild;
         free(minP);
-        minPP->lchild = NULL;
 
         return TRUE;
     }


### PR DESCRIPTION
当被删除二叉排序树的节点有左右子树时，中序遍历得到右子树的最小节点minp，将其替代被删除节点。但是在free节点minp前应考虑该节点可能存在右子树，应使其父节点minpp左指针指向minp的右子树。