### PR TITLE
获取前置节点修改

### DIFF
--- a/php/06_linkedlist/SingleLinkedList.php
+++ b/php/06_linkedlist/SingleLinkedList.php
@@ -86,6 +86,9 @@ class SingleLinkedList
 
         // 获取待删除节点的前置节点
         $preNode = $this->getPreNode($node);
+        if (empty($preNode)) {
+            return false;
+        }
 
         // 修改指针指向
         $preNode->next = $node->next;
@@ -121,7 +124,7 @@ class SingleLinkedList
      *
      * @param SingleLinkedListNode $node
      *
-     * @return SingleLinkedListNode|bool
+     * @return SingleLinkedListNode|bool|null
      */
     public function getPreNode(SingleLinkedListNode $node)
     {
@@ -133,7 +136,10 @@ class SingleLinkedList
         $preNode = $this->head;
         // 遍历找到前置节点 要用全等判断是否是同一个对象
         // http://php.net/manual/zh/language.oop5.object-comparison.php
-        while ($curNode !== $node && $curNode != null) {
+        while ($curNode !== $node) {
+            if ($curNode == null) {
+                return null;
+            }
             $preNode = $curNode;
             $curNode = $curNode->next;
         }


### PR DESCRIPTION
原代码中，假如查找的节点不在链表中，会把链表最后一个节点作为该节点的前置节点，删除时会有问题。