### PR TITLE
避免elem的next不为空导致的插入一个链表而非结点

### DIFF
--- a/c-cpp/06_linkedlist/single_list.c
+++ b/c-cpp/06_linkedlist/single_list.c
@@ -31,8 +31,7 @@ void insert(struct single_list **prev, struct single_list *elem)
 	if (!prev)
 		return;
 
-	if (*prev)
-		elem->next = *prev;
+	elem->next = *prev;
 	*prev = elem;
 }
 


### PR DESCRIPTION
修改后若原prev指向NULL，那么elem的next也指向NULL，从而若elem的next指向其他结点会将其截断，以此保证insert插入的是单个结点