### PR TITLE
修改golang版MergeSort和CountingSort，使其成为一个稳定排序

### DIFF
--- a/go/12_sorts/MergeSort.go
+++ b/go/12_sorts/MergeSort.go
@@ -27,7 +27,7 @@ func merge(arr []int, start, mid, end int) {
 	j := mid + 1
 	k := 0
 	for ; i <= mid && j <= end; k++ {
-		if arr[i] < arr[j] {
+		if arr[i] <= arr[j] {
 			tmpArr[k] = arr[i]
 			i++
 		} else {

--- a/go/14_sorts/CountingSort.go
+++ b/go/14_sorts/CountingSort.go
@@ -23,7 +23,7 @@ func CountingSort(a []int, n int) {
 	}
 
 	r := make([]int, n)
-	for i := range a {
+	for i := n - 1; i >= 0; i-- {
 		index := c[a[i]] - 1
 		r[index] = a[i]
 		c[a[i]]--


### PR DESCRIPTION
merge函数在合并两个数组时，比较arr[i]与arr[j]应该使用"<="使其成为一个稳定排序。