### PR TITLE
algo -> Python -> 17-skiplist -> optimize insert and delete

### DIFF
--- a/python/17_skiplist/skip_list.py
+++ b/python/17_skiplist/skip_list.py
@@ -39,10 +39,10 @@ class SkipList:
         if self._level_count < level: self._level_count = level
         new_node = ListNode(value)
         new_node._forwards = [None] * level
-        update = [self._head] * level     # update is like a list of prevs
+        update = [self._head] * self._level_count     # update is like a list of prevs
 
         p = self._head
-        for i in range(level - 1, -1, -1):
+        for i in range(self._level_count - 1, -1, -1): 
             while p._forwards[i] and p._forwards[i]._data < value:
                 p = p._forwards[i]
             
@@ -65,6 +65,9 @@ class SkipList:
                 if update[i]._forwards[i] and update[i]._forwards[i]._data == value:
                     update[i]._forwards[i] = update[i]._forwards[i]._forwards[i]     # Similar to prev.next = prev.next.next
 
+        while self._level_count > 1 and not self._head._forwards[self._level_count]:
+            self._level_count -= 1
+            
     def _random_level(self, p: float = 0.5) -> int:
         level = 1
         while random.random() < p and level < type(self)._MAX_LEVEL:


### PR DESCRIPTION
1. 优化跳表 Python 版本的 insert 方法
   将insert的前面查找部分第一个循环的: level 替换为 _level_count, 因为要保持insert方法的时间复杂度为 $O(logN)$ ，我们需要 insert中查找部分的时间复杂度也为 $O(logN)$, 如果使用 level 在频繁进行 insert 和 delete 时，很多时候随机生成的 level 很小，而此时 _level_count 已经很大，会导致 insert 方法退化成 $O(N)$。
2. 优化跳表 Python版本的 delete 方法
 添加当高层索引为空时，自动降层。

具体优化的对比在 [LeetCode 1206.设计跳表](https://leetcode-cn.com/problems/design-skiplist/)中有明显的体现。没有优化前会超时。
![skiplist-unoptimized](https://user-images.githubusercontent.com/19621739/74418037-b6ee3180-4e82-11ea-83b0-9dc44ec68718.PNG)
![skiplist-optimized](https://user-images.githubusercontent.com/19621739/74418048-ba81b880-4e82-11ea-9b74-df0455d91415.PNG)
