### PR TITLE
java / sorts / kthSmallest

### DIFF
--- a/java/12_sorts/KthSmallest.java
+++ b/java/12_sorts/KthSmallest.java
@@ -7,7 +7,7 @@ package sort;
 public class KthSmallest {
 
     public static int kthSmallest(int[] arr, int k) {
-        if (arr == null || arr.length < k) {
+        if (arr == null || arr.length < k || k==0) {
             return -1;
         }
 


### PR DESCRIPTION
我debug了一下发现，如果k=0的话，会一直进入else的语句，直到发生partition(arr,0,-1)数组越界的情况出现，我认为应该加上这个边界条件。