### PR TITLE
修复求无序Kth算法JS版本的错误，原算法子问题规模降低的不准确

### DIFF
--- a/javascript/12_sorts/KthNum.js
+++ b/javascript/12_sorts/KthNum.js
@@ -8,11 +8,15 @@ function kthNum(arr, k) {
   if (k > len) {
     return -1;
   }
-  let p = partition(arr, 0, len - 1);
+  let start = 0;
+  let end = len - 1;
+  let p = partition(arr, start, end);
   while (p + 1 !== k) {
     if (p + 1 > k) {
-      p = partition(arr, 0, p - 1);
+      end = p - 1
+      p = partition(arr, start, p - 1);
     } else {
+      start = p + 1
       p = partition(arr, p + 1, len - 1);
     }
   }


### PR DESCRIPTION
这个JS版本的代码应该是错误的吧，因为子问题的规模是 `n - 1`  而不是 `n / 2` ， 这复杂度应该是O(n!)级别了吧

我这边修改了之后 大约50000个数据找第10001个的实际时间从3000ms 降低到了 14ms

