### PR TITLE
Update QueueBasedOnLinkedList.go

### DIFF
--- a/go/09_queue/QueueBasedOnLinkedList.go
+++ b/go/09_queue/QueueBasedOnLinkedList.go
@@ -19,7 +19,7 @@ func NewLinkedListQueue() *LinkedListQueue {
 
 func (this *LinkedListQueue) EnQueue(v interface{}) {
 	node := &ListNode{v, nil}
-	if nil == this.tail {
+	if nil == this.head {
 		this.tail = node
 		this.head = node
 	} else {


### PR DESCRIPTION
修复问题：从队列中取完所有的值后，再向队列添加新值，无法取出