### PR TITLE
fix:java/36_ac_automata/ACAutoMata.java

### DIFF
--- a/java/36_ac_automata/ACAutoMata.java
+++ b/java/36_ac_automata/ACAutoMata.java
@@ -82,7 +82,7 @@ public class ACAutoMata {
             ACNode tmp = p;
             while ( tmp != root) {
                 if (tmp.isEndingChar == true) {
-                    System.out.println("Start from " + (i - p.length + 1));
+                    System.out.println("Start from " + (i - tmp.length + 1));
                     return true;
                 }
                 tmp = tmp.fail;


### PR DESCRIPTION
private Boolean match(String text) 方法中的结束节点输出位置错误，应为失效节点的指针即 tmp
以下测试用例可复现该bug：

        String[] patterns2 = {"哈中国","哈哈中国人"};
        String text2 = "哈哈中国人";
        System.out.println(match(text2, patterns2));

输出结果应为：Start from 1 
原代码输出为：Start from 4