### PR TITLE
fix go queue dequeue function bug

### DIFF
--- a/go/09_queue/QueueBasedOnLinkedList.go
+++ b/go/09_queue/QueueBasedOnLinkedList.go
@@ -36,6 +36,9 @@ func (this *LinkedListQueue) DeQueue() interface{} {
 	v := this.head.val
 	this.head = this.head.next
 	this.length--
+	if this.length == 0 {
+		this.tail = nil
+	}
 	return v
 }
 


### PR DESCRIPTION
当声明一个队列，并向队列中放入一个节点，然后将该节点消费，然后再往队列中加入节点时，会出现head是nil的情况。问题出在出队列时，当队列中只有一个节点时，tail并没有进行nil操作。