### PR TITLE
skiplist insert grow之后重置随机函数

### DIFF
--- a/c-cpp/17_skiplist/skiplist_tr.hpp
+++ b/c-cpp/17_skiplist/skiplist_tr.hpp
@@ -43,6 +43,11 @@ class random_level {
   public:
     random_level(IntType max_level, double prob) : dist(max_level - 1, prob) {}
     inline IntType operator()() const { return dist(gen); }
+    void reInit(IntType max_level,double prob){
+        typename std::binomial_distribution<IntType>::param_type newParm(max_level - 1, prob);
+        dist.param(newParm);
+        dist.reset();
+    }
 };
 }  // namespace skiplist_detail
 
@@ -246,7 +251,8 @@ class skiplist {
             iterator head = cont_.begin();
             auto beg_head = head->forwards.end();
             head->forwards.resize(max_lv_, tail);
-
+            
+            rl_.reInit(max_lv_, prob_);
             return;
         } else {
 #ifdef LIAM_UT_DEBUG_


### PR DESCRIPTION
原版 insert  grow 之后max_level改变，生成的随机level仍按旧max_level生成，导致后续索引中只有skiplist初始化生成的level有新节点。