### PR TITLE
fix(javascript_09): 修复出队最后一个元素以后未清空尾部数据的bug

### DIFF
--- a/javascript/09_queue/QueueBasedOnLinkedList.js
+++ b/javascript/09_queue/QueueBasedOnLinkedList.js
@@ -31,6 +31,9 @@ class QueueBasedOnLinkedList {
         if (this.head !== null) {
             const value = this.head.element
             this.head = this.head.next
+            if (this.head === null) {
+                this.tail = null
+            }
             return value
         } else {
             return -1


### PR DESCRIPTION
当出队最后一个元素以后，清空尾指针数据