### PR TITLE
Update list_queue_dequeue function

### DIFF
--- a/c-cpp/09_queue/list_queue/list_queue.c
+++ b/c-cpp/09_queue/list_queue/list_queue.c
@@ -27,6 +27,32 @@ list_queue *list_queue_create()
 
 	return queue;
 }
+
+/*出队*/
+int list_queue_dequeue(list_queue *queue,int *data)
+{
+	queue_node * ptmp = NULL;
+
+	if ((queue == NULL) || (data == NULL) || list_queue_is_empty(queue))
+	{
+		return -1;
+	}
+
+	*data = queue->head->data;
+    ptmp = queue->head;
+	queue->head = queue->head->next;
+	queue->num--;
+
+	if (queue->head == NULL)
+	{
+		queue->tail = NULL;
+	}
+
+	
+	free(ptmp);
+	return 0;
+}
+
 void list_queue_destroy(list_queue*queue)
 {
 	int i = 0;
@@ -39,6 +65,7 @@ void list_queue_destroy(list_queue*queue)
 
 	while(!list_queue_is_empty(queue))
 	{
+		/*因为这里需要用到出队函数，所以应当在使用前声明或定义出队函数*/
 		(void)list_queue_dequeue(queue,&data);
 	}
 
@@ -77,30 +104,6 @@ int list_queue_enqueue(list_queue *queue,int data)
 	return 0;
 }
 
-/*出队*/
-int list_queue_dequeue(list_queue *queue,int *data)
-{
-	queue_node * ptmp = NULL;
-
-	if ((queue == NULL) || (data == NULL) || list_queue_is_empty(queue))
-	{
-		return -1;
-	}
-
-	*data = queue->head->data;
-    ptmp = queue->head;
-	queue->head = queue->head->next;
-	queue->num--;
-
-	if (queue->head == NULL)
-	{
-		queue->tail = NULL;
-	}
-
-	
-	free(ptmp);
-	return 0;
-}
 void list_queue_dump(list_queue*queue)
 {
 	int i = 0;


### PR DESCRIPTION
修复了无法正常销毁队列的bug。
在list_queue_destroy函数中用到了list_queue_dequeue函数，但是原代码中，此时list_queue_dequeue还未定义、实现，所以会产生报错。我这里的解决方法是将list_queue_dequeue提前到list_queue_destroy之前实现。还有一种解决方法是在list_queue_destroy之前声明list_queue_dequeue。