### PR TITLE
为java代码的28_sorts中的堆排序代码增加swap函数

### DIFF
--- a/java/28_sorts/HeapSort.java
+++ b/java/28_sorts/HeapSort.java
@@ -71,4 +71,10 @@ public class HeapSort {
         }
     }
 
+	private static void swap(int[] arr, int i, int maxPos) {
+        int tmp = arr[i];
+        arr[i] = arr[maxPos];
+        arr[maxPos] = tmp;
+    }
+
 }


### PR DESCRIPTION
java代码的28_sorts中HeapSort缺少swap函数