### PR TITLE
rewrite skiplist.c, a few bug fixes

### DIFF
--- a/c-cpp/17_skiplist/SkipList.cpp
+++ b/c-cpp/17_skiplist/SkipList.cpp
@@ -354,10 +354,8 @@ int GetRandom()
 int CSkipList::RandomLevel()
 {
     int level = 1;
-    for(int i=1; i<MAX_LEVEL; ++i){
-        if(1 == (GetRandom()%3)){
-            level++;
-        }
+    for(int i=1; i<MAX_LEVEL && GetRandom()%3; ++i){
+        level++;
     }
     return level;
 }

--- a/c-cpp/17_skiplist/skiplist_c/skiplist.c
+++ b/c-cpp/17_skiplist/skiplist_c/skiplist.c
@@ -78,13 +78,8 @@ int skip_list_level(skiplist * list)
 {
 	int i = 0;
 	int level = 1;
-	for (i = 1; i < list->head->max_level; i++)
-	{
-		if ((rand()%2) == 1)
-		{
-			level++;
-		}
-	}
+	for (i = 1; i < list->head->max_level && rand() % 2; i++)
+		level++;
 
 	return level;
 }
@@ -152,6 +147,7 @@ int skip_list_insert(skiplist *list,int key,int value)
 	}
 
     list->count++;
+	free(update);
 	return 0;
 }
 
@@ -221,6 +217,7 @@ int skip_list_delete(skiplist * list, int key ,int *value)
 		return 3;/*未找到节点*/
 	}
 
+	free(update);
     return 0 ;
 }
 


### PR DESCRIPTION
原本的skiplist.c文件有几个bug，特别是random_level()函数，原本的代码实际效果是返回MAX_LEVEL的1/2左右的值。新代码已编译运行测试过。
另外扫了一下，另一个子目录里的skiplist.c也有几个bug，包括获取随机层数的函数有上述同样的问题。
另一个SkipList.cpp文件的随机函数也是同样问题。