### PR TITLE
[Rust] Fix insertion_sort error

### DIFF
--- a/rust/11_sorts/insertion_sort.rs
+++ b/rust/11_sorts/insertion_sort.rs
@@ -2,7 +2,9 @@
 /// 时间复杂度:O(n2)，原地排序算法, 稳定排序算法
 // 插入排序
 fn insertion_sort(mut nums: Vec<i32>) -> Vec<i32> {
-    if nums.is_empty() { return vec![]; }
+    if nums.is_empty() {
+        return vec![];
+    }
 
     for i in 1..nums.len() {
         let value = nums[i];
@@ -10,18 +12,18 @@ fn insertion_sort(mut nums: Vec<i32>) -> Vec<i32> {
         // 查找要插入的位置并移动数据
         while j >= 0 {
             if nums[j as usize] > value {
-                nums[(j+1) as usize] = nums[j as usize];
+                nums[(j + 1) as usize] = nums[j as usize];
             } else {
                 break;
             }
             j -= 1;
         }
-        nums[(j+1) as usize] = value;
+        nums[(j + 1) as usize] = value;
     }
     nums
 }
 
 fn main() {
     let nums = vec![4, 5, 6, 1, 2, 3];
-    println!("{:?}", insert_on_sort(nums));
+    println!("{:?}", insertion_sort(nums));
 }


### PR DESCRIPTION
Define the method name as insertion_sort. However, `insert_on_sort` is used in the main function, change it to `insertion_sort`, it works fine. And use `cargo fmt` to standardize the code format.