### PR TITLE
修复了javaScript中出队的问题

### DIFF
--- a/javascript/09_queue/QueueBasedOnLinkedList.js
+++ b/javascript/09_queue/QueueBasedOnLinkedList.js
@@ -31,6 +31,9 @@ class QueueBasedOnLinkedList {
         if (this.head !== null) {
             const value = this.head.element
             this.head = this.head.next
+            if (this.head === null) {
+                this.tail = null
+            }
             return value
         } else {
             return -1


### PR DESCRIPTION
在链表实现的队列中，当你删除最后一个元素时，head 应该设置为 null，但 tail 没有被更新为 null。因此，虽然队列为空，但 tail 仍然指向一个已删除的节点，可能会导致意外的行为或者访问错误。

正确的行为：
当队列只剩一个元素时：head 和 tail 应该指向同一个节点。
出队后，当队列为空时：head 和 tail 都应该变为 null，表示队列为空。
代码修复：
我们需要在 dequeue 方法中检查是否移除的是队列中的最后一个元素，如果是，确保同时将 head 和 tail 都设置为 null。
