### PR TITLE
:bug: fix(go/09_queue): Fix the linked list queue.

### DIFF
--- a/go/09_queue/QueueBasedOnLinkedList.go
+++ b/go/09_queue/QueueBasedOnLinkedList.go
@@ -33,8 +33,15 @@ func (this *LinkedListQueue) DeQueue() interface{} {
 	if this.head == nil {
 		return nil
 	}
+
 	v := this.head.val
 	this.head = this.head.next
+
+	// fix: keep the head and tail the same
+	if this.head == nil {
+		this.tail = nil
+	}
+
 	this.length--
 	return v
 }

--- a/go/09_queue/QueueBasedOnLinkedList_test.go
+++ b/go/09_queue/QueueBasedOnLinkedList_test.go
@@ -22,14 +22,37 @@ func TestListQueue_DeQueue(t *testing.T) {
 	q.EnQueue(5)
 	q.EnQueue(6)
 	t.Log(q)
+
+	// 1
 	q.DeQueue()
 	t.Log(q)
+
+	// 2
 	q.DeQueue()
 	t.Log(q)
+
+	// 3
 	q.DeQueue()
 	t.Log(q)
+
+	// 4
 	q.DeQueue()
 	t.Log(q)
+
+	// 5
+	q.DeQueue()
+	t.Log(q)
+
+	// 6 note: all of the nodes are dequeue
+	// head = tail = nil
+	q.DeQueue()
+	t.Log(q)
+
+	// enqueue
+	q.EnQueue(1)
+	t.Log(q)
+
+	// head = tail = nil
 	q.DeQueue()
 	t.Log(q)
 }


### PR DESCRIPTION
When all of the nodes are dequeue, keep the head and tail the same.